### PR TITLE
Speed improvements with -s|--skip

### DIFF
--- a/src/pp.c
+++ b/src/pp.c
@@ -865,21 +865,32 @@ int main (int argc, char *argv[])
 
       const u64 iter_max_u64 = mpz_get_ui (iter_max);
 
-      for (u64 iter_pos_u64 = 0; iter_pos_u64 < iter_max_u64; iter_pos_u64++)
-      {
-        mpz_add_ui (tmp, elem_buf->ks_pos, iter_pos_u64);
+      mpz_add (tmp, total_ks_pos, iter_max);
 
-        if (mpz_cmp (total_ks_pos, skip) >= 0)
+      if (mpz_cmp (tmp, skip) > 0)
+      {
+        u64 iter_pos_u64 = 0;
+
+        if (mpz_cmp (total_ks_pos, skip) < 0)
         {
+          mpz_sub (tmp, skip, total_ks_pos);
+
+          iter_pos_u64 = mpz_get_ui (tmp);
+        }
+
+        for (; iter_pos_u64 < iter_max_u64; iter_pos_u64++)
+        {
+          mpz_add_ui (tmp, elem_buf->ks_pos, iter_pos_u64);
+
           elem_set_pwbuf (elem_buf, db_entries, tmp, pw_buf);
 
           out_push (out, pw_buf, pw_len + 1);
         }
 
-        mpz_add_ui (total_ks_pos, total_ks_pos, 1);
+        out_flush (out);
       }
 
-      out_flush (out);
+      mpz_add (total_ks_pos, total_ks_pos, iter_max);
 
       mpz_add (elem_buf->ks_pos, elem_buf->ks_pos, iter_max);
 


### PR DESCRIPTION
Benchmarks with "time ./pp64.bin -l 10 -s **** < rockyou-top50k.txt"

New skip 100,000,000: 0.095s
Current skip 100,000,000: 2.535s

New skip 1,000,000,000: 0.115s
Current skip 1,000,000,000: 24.583s

New skip 100,000,000,000: 10.520s

I'm still a little disappointed in the new version's speed. There is one more thing that can be done. Initializing db_entries[*]->elems_pos and db_entries[*]->elems_buf[db_entries[*]->elems_pos]->ks_pos before the main loop. I have some ideas as to doing this semi-efficiently. I'll probably do that tonight.