### PR TITLE
Allow hex input for --skip and --limit.

### DIFF
--- a/src/pp.c
+++ b/src/pp.c
@@ -544,8 +544,8 @@ int main (int argc, char *argv[])
       case IDX_ELEM_CNT_MIN:  elem_cnt_min    = atoi (optarg);  break;
       case IDX_ELEM_CNT_MAX:  elem_cnt_max    = atoi (optarg);  break;
       case IDX_WL_DIST_LEN:   wl_dist_len     = 1;              break;
-      case IDX_SKIP:          mpz_set_str (skip,  optarg, 10);  break;
-      case IDX_LIMIT:         mpz_set_str (limit, optarg, 10);  break;
+      case IDX_SKIP:          mpz_set_str (skip,  optarg, 0);   break;
+      case IDX_LIMIT:         mpz_set_str (limit, optarg, 0);   break;
       case IDX_OUTPUT_FILE:   output_file     = optarg;         break;
 
       default: return (-1);

--- a/src/pp.c
+++ b/src/pp.c
@@ -224,7 +224,8 @@ static void check_realloc_elems (db_entry_t *db_entry)
 
     if (db_entry->elems_buf == NULL)
     {
-      fprintf (stderr, "Out of memory!\n");
+      fprintf (stderr, "Out of memory trying to allocate %zu bytes!\n",
+               (size_t)elems_alloc_new * sizeof (elem_t));
 
       exit (-1);
     }
@@ -247,7 +248,8 @@ static void check_realloc_chains (db_entry_t *db_entry)
 
     if (db_entry->chains_buf == NULL)
     {
-      fprintf (stderr, "Out of memory!\n");
+      fprintf (stderr, "Out of memory trying to allocate %zu bytes!\n",
+               (size_t)chains_alloc_new * sizeof (chain_t));
 
       exit (-1);
     }


### PR DESCRIPTION
Mostly for testing but it never hurts
```
$ echo $((0xcafebabe))
3405691582

$ pp64.app --skip 3405691582 --limit 5 < rockyou.lst 
luieh1i
2527h1i
iyoth1i
5398h1i
2087h1i

$ pp64.app --skip 0xcafebabe --limit 5 < rockyou.lst 
luieh1i
2527h1i
iyoth1i
5398h1i
2087h1i
```