### PR TITLE
Dynamically allocate buffers. Use Solar's mem_alloc_tiny to avoid malloc overhead.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -20,3 +20,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+------
+
+mem_alloc_tiny() is nicked from John the Ripper password cracker,
+Copyright (c) 1996-98,2003,2010-2012 by Solar Designer
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted.
+
+There's ABSOLUTELY NO WARRANTY, express or implied.


### PR DESCRIPTION
Closes #24, closes #25.