### PR TITLE
Fix regression problem (memory use) with recent patch.

### DIFF
--- a/src/pp.c
+++ b/src/pp.c
@@ -33,7 +33,7 @@
 #define CASE_PERMUTE  0
 #define DUPE_CHECK    1
 
-#define DUPE_HASH_LOG 26
+#define DUPE_HASH_LOG 23
 
 #define VERSION_BIN   20
 


### PR DESCRIPTION
Decrease DUPE_HASH_LOG from 27 to 23 to compensate for new code with one table per length. Now for rockyou-with-dupes memory is again back under ~800 MB, and speed was restored on a 4 GB machine. (2 secs better than my original patch).