### PR TITLE
More bug fixes for min/max length in dupe checking. See #38, #40.

### DIFF
--- a/src/pp.c
+++ b/src/pp.c
@@ -850,7 +850,9 @@ int main (int argc, char *argv[])
 
   if (dupe_check)
   {
-    for (int pw_len = IN_LEN_MIN; pw_len <= pw_max; pw_len++)
+    int in_max = MIN(IN_LEN_MAX, pw_max);
+
+    for (int pw_len = IN_LEN_MIN; pw_len <= in_max; pw_len++)
     {
       db_entry_t *db_entry = &db_entries[pw_len];
 
@@ -956,7 +958,9 @@ int main (int argc, char *argv[])
 
   if (dupe_check)
   {
-    for (int pw_len = pw_min; pw_len <= pw_max; pw_len++)
+    int in_max = MIN(IN_LEN_MAX, pw_max);
+
+    for (int pw_len = IN_LEN_MIN; pw_len <= in_max; pw_len++)
     {
       db_entry_t *db_entry = &db_entries[pw_len];
 


### PR DESCRIPTION
Please review. For dupe-checking we should never go past input length. Also, that #38 bugfix in #40 was not complete - the same thing was needed in another place. 