### PR TITLE
Add Apple Silicon support in Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,7 @@ CC_WINDOWS32      = /usr/bin/i686-w64-mingw32-gcc
 CC_WINDOWS64      = /usr/bin/x86_64-w64-mingw32-gcc
 CC_OSX32          = /usr/bin/i686-apple-darwin10-gcc
 CC_OSX64          = /usr/bin/i686-apple-darwin10-gcc
+CC_APPLE_ARM64    = gcc
 
 CFLAGS_LINUX32    = $(CFLAGS) -m32 -DLINUX
 CFLAGS_LINUX64    = $(CFLAGS) -m64 -DLINUX
@@ -18,29 +19,33 @@ CFLAGS_WINDOWS32  = $(CFLAGS) -m32 -DWINDOWS
 CFLAGS_WINDOWS64  = $(CFLAGS) -m64 -DWINDOWS
 CFLAGS_OSX32      = $(CFLAGS) -m32 -DOSX
 CFLAGS_OSX64      = $(CFLAGS) -m64 -DOSX
-
-all: pp64.bin
+CFLAGS_APPLE_ARM64= $(CFLAGS) -arch arm64 -DAPPLE
+all: pp64.bin ppAppleArm64.bin
 
 pp32: pp32.bin pp32.exe pp32.app
 pp64: pp64.bin pp64.exe pp64.app
+ppAppleArm64: ppAppleArm64.bin
 
 clean:
-	rm -f pp32.bin pp64.bin pp32.exe pp64.exe pp32.app pp64.app
+	rm -f pp32.bin pp64.bin pp32.exe pp64.exe pp32.app pp64.app ppAppleArm64.bin
 
 pp32.bin: pp.c mpz_int128.h
-	$(CC_LINUX32)   $(CFLAGS_LINUX32)   -o $@ $^
+	$(CC_LINUX32)   $(CFLAGS_LINUX32)   -o $@ pp.c
 
 pp64.bin: pp.c mpz_int128.h
-	$(CC_LINUX64)   $(CFLAGS_LINUX64)   -o $@ $^
+	$(CC_LINUX64)   $(CFLAGS_LINUX64)   -o $@ pp.c
 
 pp32.exe: pp.c mpz_int128.h
-	$(CC_WINDOWS32) $(CFLAGS_WINDOWS32) -o $@ $^
+	$(CC_WINDOWS32) $(CFLAGS_WINDOWS32) -o $@ pp.c
 
 pp64.exe: pp.c mpz_int128.h
-	$(CC_WINDOWS64) $(CFLAGS_WINDOWS64) -o $@ $^
+	$(CC_WINDOWS64) $(CFLAGS_WINDOWS64) -o $@ pp.c
 
 pp32.app: pp.c mpz_int128.h
-	$(CC_OSX32)     $(CFLAGS_OSX32)     -o $@ $^
+	$(CC_OSX32)     $(CFLAGS_OSX32)     -o $@ pp.c
 
 pp64.app: pp.c mpz_int128.h
-	$(CC_OSX64)     $(CFLAGS_OSX64)     -o $@ $^
+	$(CC_OSX64)     $(CFLAGS_OSX64)     -o $@ pp.c
+
+ppAppleArm64.bin: pp.c mpz_int128.h
+	$(CC_APPLE_ARM64) $(CFLAGS_APPLE_ARM64) -o $@ pp.c


### PR DESCRIPTION
I've added support for Apple's ARM64 architecture in the Makefile. This will enable users with Apple Silicon Macs to compile the project seamlessly. Please find the changes below.

**Changes:**

- Added a new compiler option CC_APPLE_ARM64 for Apple Silicon.
- Defined CFLAGS_APPLE_ARM64 flags.
- Included a new target ppAppleArm64.bin to build specifically for Apple Silicon.

Would appreciate it if you could take a look and merge it if everything looks good.
